### PR TITLE
add include and exclude comma separate lists for paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.10.7-alpine
 
 ADD requirements.txt /requirements.txt
 ADD validator.py /validator.py

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ usage: validator.py [-h] schema_path document_path [validate_file_extension] [fi
 YAML validator
 
 positional arguments:
-  schema_path           Path to the YAML schema to validate against
-  document_path         Path to the YAML document or directory of documents to be validated. Accepts globs. Defaults to recursive search if only a directory is provided.
-  validate_file_extension
-                        Validate that all the given documents have a file extension as specified by filter_extensions. Default: false
-  filter_extensions     Only the files with these extensions will be checked. Default: .yml,.yaml
+  schema_path              Path to the YAML schema to validate against
+  include_document_paths   A comma separated list of paths to the YAML document or directory of documents to be validated. Accepts globs. 
+  exclude_document_paths   A comma separated exclude list of paths to the YAML document or directory of documents to be validated. Accepts globs. 
+  validate_file_extension  Validate that all the given documents have a file extension as specified by filter_extensions. Default: false
+  filter_extensions        Only the files with these extensions will be checked. Default: .yml,.yaml
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -51,7 +51,7 @@ Users:
 ### Required parameters
 
 - `schema_path` - Path to the YAML schema to validate against
-- `document_path` - Path to the YAML document or directory of documents to be validated. Accepts globs.
+- `include_document_paths` - A comma separated list of paths to the YAML document or directory of documents to be validated. Accepts globs.
 
 ### Optional parameters
 
@@ -69,7 +69,8 @@ jobs:
     - uses: navikt/yaml-validator@v4
       with:
         schema_path: schema.yaml
-        document_path: document.yaml
+        include_document_paths: document.yaml,dir/*
+        exclude_document_paths: dir/not_these_files*
         validate_file_extension: 'no' # optional, defaults shown, enum of ['yes', 'no']
         filter_extensions: '.yml,.yaml' # optional, defaults shown
 ```

--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,12 @@ inputs:
   schema_path:
     description: 'Path to the YAML schema to validate against'
     required: true
-  document_path:
-    description: 'Path to the YAML document to be validated'
+  include_document_paths:
+    description: 'A comma separated list of paths to the YAML document or directory of documents to be validated. Accepts globs.'
     required: true
+  exclude_document_paths:
+    description: 'A comma separated exclude list of paths to the YAML document or directory of documents to be validated. Accepts globs. Default: "" '
+    required: false
   validate_file_extension:
     description: 'Validate that all the given documents have a file extension as specified by filter_extensions. Default: false'
     required: false
@@ -23,7 +26,8 @@ runs:
   image: 'docker://navikt/yaml-validator:v4'
   args:
     - ${{ inputs.schema_path }}
-    - ${{ inputs.document_path }}
+    - ${{ inputs.include_document_paths }}
+    - ${{ inputs.exclude_document_paths }}
     - ${{ inputs.validate_file_extension }}
     - ${{ inputs.filter_extensions }}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Cerberus==1.3.2
-PyYAML==5.4
+PyYAML==5.3.1

--- a/validator.py
+++ b/validator.py
@@ -145,7 +145,7 @@ def main():
     filter_extensions = args.filter_extensions.split(',')
 
     matching_files = _filter_paths(include_document_paths.split(','), exclude_document_paths.split(','))
-    _validate_path(schema_path, matching_files, validate_file_extension, filter_extensions)
+    _validate_path(os.path.abspath(os.path.expanduser(schema_path)), matching_files, validate_file_extension, filter_extensions)
 
 
 if __name__ == "__main__":

--- a/validator.py
+++ b/validator.py
@@ -2,6 +2,8 @@ import argparse
 import logging
 import sys
 import yaml
+import glob
+import os
 
 try:
     from yaml import CFullLoader as Loader
@@ -58,7 +60,7 @@ def _load_yaml_document(path):
 
 
 def _validate_single(schema_path, document_path, validate_file_extension, filter_extensions):
-    if document_path.suffix not in filter_extensions :
+    if Path(document_path).suffix not in filter_extensions :
         if validate_file_extension and not document_path.is_dir():
             logging.error(f"❌\t'{document_path}' does not have a file extension matching [.yml, .yaml].")
             return False
@@ -75,9 +77,9 @@ def _validate_single(schema_path, document_path, validate_file_extension, filter
     return valid
 
 
-def _validate_path(root, schema_path, document_paths, validate_file_extension, filter_extensions):
+def _validate_path(schema_path, document_paths, validate_file_extension, filter_extensions):
     results = [
-        (path.relative_to('./'), _validate_single(schema_path, path.relative_to('./'), validate_file_extension, filter_extensions))
+        (path, _validate_single(schema_path, path, validate_file_extension, filter_extensions))
         for path in document_paths
     ]
     results = list(filter(lambda x: x[1] is not None, results))
@@ -86,34 +88,46 @@ def _validate_path(root, schema_path, document_paths, validate_file_extension, f
 
     if any(not is_valid for (_, is_valid) in results):
         invalid_count = len([(path, is_valid) for (path, is_valid) in results if not is_valid])
-        logging.error(f"{invalid_count} of {total_count} document(s) in '{root}' failed to validate:")
+        logging.error(f"{invalid_count} of {total_count} document(s) failed to validate:")
         [logging.error(f'❌\t{path}') for (path, is_valid) in results if not is_valid]
         sys.exit(1)
     else:
-        logging.info(f"✅\t{total_count} of {total_count} documents in '{root}' are valid!")
+        logging.info(f"✅\t{total_count} of {total_count} documents are valid!")
 
 
-def _process(schema_path, document_path, validate_file_extension, filter_extensions):
-    logging.info(f"😘\tValidating '{document_path}' against schema '{schema_path}'...")
+def _filter_paths(include_paths, exclude_paths):
+    expanded_included_paths = _expand_paths(include_paths)
+    expanded_excluded_paths = _expand_paths(exclude_paths)
 
-    root = Path(document_path).relative_to('./')
-    paths = Path('.').glob(document_path)
+    matching_files = []
 
-    if Path(document_path).is_dir():
-        if not document_path.endswith('/'):
-            document_path = document_path + '/'
-        paths = Path('.').glob(document_path + '**/*')
+    # Filter out excluded paths from included paths
+    for path in expanded_included_paths:
+        if all(exclude_path not in path for exclude_path in expanded_excluded_paths):
+            matching_files.append(path)
 
-    _validate_path(root, schema_path, paths, validate_file_extension, filter_extensions)
+    return matching_files
 
+def _expand_paths(paths):
+    expanded_paths = []
+    for path in paths:
+        path_expanded = os.path.expanduser(path)
+        path_absolute = os.path.abspath(path_expanded)
+        expanded_paths.extend(glob.glob(path_absolute))
+
+    return expanded_paths
 
 def main():
     logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(levelname)-6s %(message)s")
     parser = argparse.ArgumentParser(description='YAML validator')
     parser.add_argument("schema_path", help="Path to the YAML schema to validate against")
-    parser.add_argument("document_path", help="Path to the YAML document or directory of documents to be validated. "
-                                              "Accepts globs. Defaults to recursive search if only a directory is "
-                                              "provided.")
+    parser.add_argument("include_document_paths", help="A comma separated list of paths to the YAML document or directory of documents to be validated. "
+                                              "Accepts globs.")
+
+    parser.add_argument("exclude_document_paths", help="A comma separated exclude list of paths to the YAML document or directory of documents to be validated. "
+                                              "Accepts globs.",
+                        default="",
+                        nargs='?')
     parser.add_argument("validate_file_extension",
                         default="false",
                         nargs='?',
@@ -124,11 +138,14 @@ def main():
                         help="Only the files with these extensions will be checked. Default: .yml,.yaml")
     args = parser.parse_args()
     schema_path = args.schema_path
-    document_path = args.document_path
+    include_document_paths = args.include_document_paths
+    exclude_document_paths = args.exclude_document_paths
+
     validate_file_extension = bool(strtobool(args.validate_file_extension.lower()))
     filter_extensions = args.filter_extensions.split(',')
 
-    _process(schema_path, document_path, validate_file_extension, filter_extensions)
+    matching_files = _filter_paths(include_document_paths.split(','), exclude_document_paths.split(','))
+    _validate_path(schema_path, matching_files, validate_file_extension, filter_extensions)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
With this change, the user can provide an include and an exclude comma separated paths that can be helpful in filtering files that should not be targeted. This means that the argument `document_path` is replaced with `include_document_paths` and `exclude_documents_paths`

Breaking change: Does not default to recursive search if the directory is not provided. Instead, it is an easy switch to use a glob, like `dir/*` or `dir/**/*`.